### PR TITLE
SOE-2350: added function to check for first sidebar and node

### DIFF
--- a/stanford_cache_helper.install
+++ b/stanford_cache_helper.install
@@ -27,10 +27,10 @@ function stanford_cache_helper_install() {
  * Implements hook_enable().
  */
 function stanford_cache_helper_enable() {
-  /*
-   *mymodule_cache_rebuild();
-   */
-  /* Your code here */
+
+  // Initialize settings
+  $settings = stanford_cache_helper_get_settings();
+  variable_set('stanford_cache_helper_settings', $settings);
 }
 
 /**
@@ -47,7 +47,5 @@ function stanford_cache_helper_disable() {
  * Implements hook_uninstall().
  */
 function stanford_cache_helper_uninstall() {
-  /*
-   *variable_del('upload_file_types');
-   */
+  variable_del('stanford_cache_helper_settings');
 }

--- a/stanford_cache_helper.module
+++ b/stanford_cache_helper.module
@@ -37,9 +37,9 @@ function stanford_cache_helper_page_alter(&$page) {
   if (!isset($page['sidebar_first'])) {
     if (isset ($page['content']['system_main']['nodes'])) {
       $key = (key($page['content']['system_main']['nodes']));
-      $white_list = array(628, 148);
+      $settings = stanford_cache_helper_get_settings();
 
-      if (!in_array($key, $white_list)) {
+      if (!in_array($key, $settings['whitelist'])) {
         watchdog('stanford_cache_helper',
           'First sidebar is missing. Page is: node/%key',
           array('%key' => $key),
@@ -50,8 +50,27 @@ function stanford_cache_helper_page_alter(&$page) {
   }
 }
 
-/*
- * Whitelist:
- * node/628 - Information Technology
- * node/148 - Home page
+/**
+ * Default settings wrapper for variable_get
+ * @return array
+ *   Persistent settings for this module.
+ *
  */
+function stanford_cache_helper_get_settings() {
+  $default_settings = array(
+
+    // These are the nodes that don't have first sidebars.
+    // node/628 - Information Technology
+    // node/148 - Home page
+    // node/1225 - Connect-links
+    // node/632 - Job Aids Too
+    // node/80  - page not found
+    // node/164 - Resources Overview
+    // node/90  - Resources
+    // node/78  - Programs
+    'whitelist' => array(628, 148, 1225, 632, 80, 164, 90, 78),
+  );
+  $settings = variable_get('stanford_cache_helper_settings', $default_settings );
+
+  return $settings;
+}

--- a/stanford_cache_helper.module
+++ b/stanford_cache_helper.module
@@ -37,12 +37,21 @@ function stanford_cache_helper_page_alter(&$page) {
   if (!isset($page['sidebar_first'])) {
     if (isset ($page['content']['system_main']['nodes'])) {
       $key = (key($page['content']['system_main']['nodes']));
-      watchdog('stanford_cache_helper',
-        'First sidebar is missing. Page is: node/%key',
-        array('%key' => $key),
-        WATCHDOG_DEBUG);
-      //drupal_flush_all_caches();
-      $block = module_invoke('menu_block', 'block_view', 'stanford_jsa_layouts-1');
+      $white_list = array(628, 148);
+
+      if (!in_array($key, $white_list)) {
+        watchdog('stanford_cache_helper',
+          'First sidebar is missing. Page is: node/%key',
+          array('%key' => $key),
+          WATCHDOG_DEBUG);
+        drupal_flush_all_caches();
+      }
     }
   }
 }
+
+/*
+ * Whitelist:
+ * node/628 - Information Technology
+ * node/148 - Home page
+ */

--- a/stanford_cache_helper.module
+++ b/stanford_cache_helper.module
@@ -41,7 +41,8 @@ function stanford_cache_helper_page_alter(&$page) {
         'First sidebar is missing. Page is: node/%key',
         array('%key' => $key),
         WATCHDOG_DEBUG);
-      drupal_flush_all_caches();
+      //drupal_flush_all_caches();
+      $block = module_invoke('menu_block', 'block_view', 'stanford_jsa_layouts-1');
     }
   }
 }

--- a/stanford_cache_helper.module
+++ b/stanford_cache_helper.module
@@ -32,6 +32,8 @@ function stanford_cache_helper_page_alter(&$page) {
 
   // If the page doesn't have a sidebar and it is displaying a node, it might
   // need the cache cleared.
+  //
+  // This requires refreshing the page twice for the page to render properly.
   if (!isset($page['sidebar_first'])) {
     if (isset ($page['content']['system_main']['nodes'])) {
       $key = (key($page['content']['system_main']['nodes']));
@@ -39,7 +41,7 @@ function stanford_cache_helper_page_alter(&$page) {
         'First sidebar is missing. Page is: node/%key',
         array('%key' => $key),
         WATCHDOG_DEBUG);
-      cache_clear_all();
+      drupal_flush_all_caches();
     }
   }
 }

--- a/stanford_cache_helper.module
+++ b/stanford_cache_helper.module
@@ -24,3 +24,22 @@ function stanford_cache_helper_block_view_alter(&$data, $block) {
     }
   }
 }
+
+/**
+ * Implements hook_page_alter(&$page).
+ */
+function stanford_cache_helper_page_alter(&$page) {
+
+  // If the page doesn't have a sidebar and it is displaying a node, it might
+  // need the cache cleared.
+  if (!isset($page['sidebar_first'])) {
+    if (isset ($page['content']['system_main']['nodes'])) {
+      $key = (key($page['content']['system_main']['nodes']));
+      watchdog('stanford_cache_helper',
+        'First sidebar is missing. Page is: node/%key',
+        array('%key' => $key),
+        WATCHDOG_DEBUG);
+      cache_clear_all();
+    }
+  }
+}


### PR DESCRIPTION
# READY FOR REVIEW

# Summary
- This implements a function to look for a sidebar on a page with a node. If it is not there, flush the cache. 

# Needed By (Date)
- Sprint end

# Criticality
- Client is eagerly awaiting this.
- Fixes broken stuff

# Steps to Test

- download this branch
- disable, uninstall, and re-enable this module
- Verify that the `stanford_cache_helper_settings` are set:

```
drush vget stanford_cache_helper_settings
stanford_cache_helper_settings:
  whitelist:
    - 628
    - 148
    - 1225
    - 632
    - 80
    - 164
    - 90
    - 78
```

These are the _Stanford Pages_ and _Stanford Landing Pages_ that have no first sidebar.
- Navigate to /private (This page is not being used and should really be unpublished, but it makes a great test page.)
- Verify in the log or (`drush ws --tail`) you see: 
```debug   stanford_cache_helper  First sidebar is missing. Page is: node/190```
- Navigate to any of those nodes ^ i.e. `node/628` and verify there's no such entry in the log.

# Affects 
- SoE (School of Engineering website)

# Associated Issues and/or People
## Related JIRA ticket(s)

## Related PRs

## More Information

After this is approved and merged please put it on the `https://insidesoe.stanford.edu/` site at `/var/www/ds_jse-soe-intranet`
(remember to disable, uninstall, and re-enable this module)


## Folks to notify
@kbrownell 


# See Also
- [PR Checklist](https://gist.github.com/sherakama/0ba17601381e3adbe0cad566ad4d80a5)